### PR TITLE
Add subtitles to listItem instead of player.

### DIFF
--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -82,8 +82,8 @@ def play(item, subtitle=None):
     )
 
     listItem.setInfo('video', {'Title': item.name})
-    player.play(item.stream_url, listItem)
-
     if subtitle:
-        print "Adding subtitle to player!"
-        player.setSubtitles(subtitle)
+        print "Adding subtitle to listItem!"
+        listItem.setSubtitles([subtitle])
+
+    player.play(item.stream_url, listItem)


### PR DESCRIPTION
I was trying to get original feature work, but didn't manage. Looking
through the Kodi API I've found there's also `setSubtitles` directly on
ListItem which does work for me.

So, here I propose changing that, but in case I've missed something that
makes a difference while set for player directly, I can make any changes
suggested.